### PR TITLE
Faster IP lookup

### DIFF
--- a/dockerhost
+++ b/dockerhost
@@ -44,11 +44,19 @@ EOF
         multipass info dockerhost
         ;;
     ip)
-        ip=$(multipass info dockerhost --format json | jq -r '.info.dockerhost.ipv4[0]')
+        ip=$(multipass list --format json | jq -r '.list[] | select(.name == "dockerhost") | .ipv4[0]')
+        if [ "$ip" = "null" ]; then
+            echo "dockerhost not started" 1>&2
+            exit 1
+        fi
         echo "$ip"
         ;;
     env)
-        ip=$(multipass info dockerhost --format json | jq -r '.info.dockerhost.ipv4[0]')
+        ip=$(multipass list --format json | jq -r '.list[] | select(.name == "dockerhost") | .ipv4[0]')
+        if [ "$ip" = "null" ]; then
+            echo "dockerhost not started" 1>&2
+            exit 1
+        fi
         echo "export DOCKER_HOST=\"tcp://$ip:$port\""
         ;;
     exec)


### PR DESCRIPTION
### What
Make IP lookup of the docker host faster.

### Why
It currently takes about 1.3 seconds to lookup the host IP. Using the `multipass list` command is a bit over twice as fast. It's still not great clocking in at around 500ms, but it's better.

Related canonical/multipass#2314